### PR TITLE
Add meaningful error message before crashing when bundle identifier cant be found

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,8 @@
 
 ## Fixed
 
+- #46 An invalid identifier produces a bogus error
+
 -
 
 ## Miscellaneous

--- a/lib/crep/model/crash_sources/hockeyapp_crash_source.rb
+++ b/lib/crep/model/crash_sources/hockeyapp_crash_source.rb
@@ -15,6 +15,7 @@ module Crep
 
       @client = HockeyApp.build_client
       @hockeyapp_app = hockeyapp(bundle_identifier, @client)
+      CrepLogger.error("No app with the give bundle identifier (#{bundle_identifier}) was found.") unless @hockeyapp_app
       @app = App.new(@hockeyapp_app.title, bundle_identifier)
     end
 

--- a/lib/crep/model/crash_sources/hockeyapp_crash_source.rb
+++ b/lib/crep/model/crash_sources/hockeyapp_crash_source.rb
@@ -74,7 +74,7 @@ module Crep
         app.bundle_identifier == bundle_identifier
       end
       if !apps.first
-        CrepLogger.error("No app with the give bundle identifier (#{bundle_identifier}) was found.") unless apps.first
+        CrepLogger.error("No app with the give bundle identifier (#{bundle_identifier}) was found.")
         raise
       end
       apps.first

--- a/lib/crep/model/crash_sources/hockeyapp_crash_source.rb
+++ b/lib/crep/model/crash_sources/hockeyapp_crash_source.rb
@@ -15,7 +15,6 @@ module Crep
 
       @client = HockeyApp.build_client
       @hockeyapp_app = hockeyapp(bundle_identifier, @client)
-      CrepLogger.error("No app with the give bundle identifier (#{bundle_identifier}) was found.") unless @hockeyapp_app
       @app = App.new(@hockeyapp_app.title, bundle_identifier)
     end
 
@@ -53,7 +52,10 @@ module Crep
     def version(version:, build:)
       filtered_versions = filtered_versions_by_version_and_build(@hockeyapp_app.versions, version, build)
 
-      raise "No version was found for #{version})#{build})".red unless filtered_versions.count > 0
+      if filtered_versions.count <= 0
+        CrepLogger.error("No version was found for #{version})#{build})")
+        raise
+      end
 
       report_version = filtered_versions.first
 
@@ -70,6 +72,10 @@ module Crep
       all_apps = client.get_apps
       apps = all_apps.select do |app|
         app.bundle_identifier == bundle_identifier
+      end
+      if !apps.first
+        CrepLogger.error("No app with the give bundle identifier (#{bundle_identifier}) was found.") unless apps.first
+        raise
       end
       apps.first
     end


### PR DESCRIPTION
Adds a log before exiting from the program so you know what went wrong. See the screenshot below.
Fixes #46

![terminal](https://user-images.githubusercontent.com/8986441/35151211-c9e3aabc-fd1d-11e7-8097-3707a491eac7.png)


<!--
First of all, thank you for contributing to Crep! 🎉

If your pull request fixes an issue, please reference the issue.
For example, when your pull request fixes issue 10, add the following line:

Fixes #10

This will make sure that when the pull request is merged, the issue will automatically be closed.
-->
