### PR TITLE
[Copy] Change "Newsletters" to more generic/extendable "Reports"

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,10 +1,10 @@
 # Crep
 
-*Crep - a Crash Reporter for creating appealing Crash Newsletters*
+*Crep - a Crash Reporter for creating appealing Crash Reports*
 
 We use Crep at [XING](https://www.xing.com) to create our Crash Newsletters for [iOS](https://www.xing.com/ios) and [Android](https://www.xing.com/android) within the _Mobile Releases Team_. It currently uses [HockeyApp](https://rink.hockeyapp.net) as a crash source, so if you are using Hockey, you should definitely give Crep a try.
 
-In case you are creating Crash Newsletters and have a different crash source in mind - check out the contributing section!
+In case you are creating Crash Reports and have a different crash source in mind - check out the contributing section!
 
 ## Install
 

--- a/Vision.md
+++ b/Vision.md
@@ -1,6 +1,6 @@
 # Goals
 
-- Add newsletter templating to easily create a readable and actionable format for sharing crashes.
+- Add templating support for reports to easily create a readable and actionable format for sharing crashes.
 - Add multiple crash sources, making it easier for anyone to plug and play.
 - Enable newsletters or results to be easily published on sites like GitHub.
 - Cultivate an inclusive open source community through respectful discussion.
@@ -8,7 +8,7 @@
 # Scope
 
 - We are focusing on crashes for a specific app version.
-- Having a crash newsletter in mind, we do not expect adding crash visualisations.
+- We do not expect adding crash visualisations.
 
 ## Inspiration
 

--- a/crep.gemspec
+++ b/crep.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Kim Dung-Pham', 'Bas Broek', 'Serghei Moret']
   spec.email         = ['kim.dung-pham@xing.com', 'bas.broek@xing.com', 'serghei.moret@xing.com']
 
-  spec.summary       = 'Create Crash Newsletter with ease.'
-  spec.description   = 'Create Crash Newsletter with ease. Really.'
+  spec.summary       = 'Create Crash Reports with ease.'
+  spec.description   = 'Create Crash Reports with ease. Really.'
   spec.homepage      = 'https://github.com/xing/crep'
   spec.license       = 'MIT'
 


### PR DESCRIPTION
We discussed making the templating not strictly for newsletter, but any form of report. Inspired by [this comment](https://github.com/rnystrom/GitHawk/issues/848#issuecomment-358521922).